### PR TITLE
v1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flowfuse/node-red-dashboard-2-user-addon",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A Node-RED Plugin to extend Node-RED Dashboard 2.0 with user session data on SocketIO events",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Version Bump

Okay for review, but not merge. Needs to coincide with `1.10.0` of Node-RED Dashboard 2.0